### PR TITLE
take account of json files passed into the .bumpversion file

### DIFF
--- a/bin/sync_versions.js
+++ b/bin/sync_versions.js
@@ -16,6 +16,21 @@ const versionPath = path.join(process.cwd(), ".version");
 
 let version = "0.0.0";
 
+function updateJSON(filename, version) {
+  const filepath = path.join(process.cwd(), filename) 
+  return fs.readFile(filepath, "utf8")
+    .then((fileContent) => JSON.parse(fileContent))
+    .then((json) => {
+      if (json.version) {
+        json.version = version;
+      }
+      // lke-plugins manifest update
+      if (json.pluginApiVersion) {
+        json.pluginApiVersion = version;
+      }
+      return fs.writeFile(filepath, JSON.stringify(json));
+    })
+}
 fs.readFile(path.join(process.cwd(), "package.json"), "utf8")
   .then((packageJson) => (version = JSON.parse(packageJson).version))
   .then(() => fs.readFile(cfgPath, "utf8"))
@@ -24,7 +39,16 @@ fs.readFile(path.join(process.cwd(), "package.json"), "utf8")
       /current_version\s*=\s*[^\n]*/i,
       `current_version = ${version}`
     );
-    return fs.writeFile(cfgPath, updated, "utf8");
+    // update the files specified in the .bumpversion file
+    const matches = cfg.match(/\[bumpversion:file:(.*)\]/g);
+    let updateFiles = Promise.resolve();
+    if (matches && matches.length) {
+      updateFiles = updateFiles.then(() => Promise.all(matches
+        .map(m => m.match(/\[bumpversion:file:(.*)\]/)[1])
+        .filter(filepath => filepath && filepath.endsWith('.json'))
+        .map(filepath =>  updateJSON(filepath, version))));
+    }
+    return updateFiles.then(() => fs.writeFile(cfgPath, updated, "utf8"));
   })
   .then(() => fs.writeFile(versionPath, version, "utf8"))
   .catch((e) => {


### PR DESCRIPTION
Some projects have a list of files to update in the `.bumpconfig` file: `lke-pluins` have the `manifest.json`
 
So we just read the file, take all the matches, and update JSON files.  