### PR TITLE
format output json

### DIFF
--- a/bin/sync_versions.js
+++ b/bin/sync_versions.js
@@ -28,7 +28,7 @@ function updateJSON(filename, version) {
       if (json.pluginApiVersion) {
         json.pluginApiVersion = version;
       }
-      return fs.writeFile(filepath, JSON.stringify(json));
+      return fs.writeFile(filepath, JSON.stringify(json, 0,2));
     })
 }
 fs.readFile(path.join(process.cwd(), "package.json"), "utf8")


### PR DESCRIPTION
Format output json: `package-lock` is formated and it is preferable to not overrite it with non formated version